### PR TITLE
Add expect_to_not_see_log_message[s] to TestHelpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # yeti_logger changelog
 
+## v3.1.0
+- Added `YetiLogger::TestHelper.expect_to_not_see_log_message[s]` for testing
+  that given messages were not logged at the given log level.
+  
 ## v3.0.0
 - First public release

--- a/lib/yeti_logger/version.rb
+++ b/lib/yeti_logger/version.rb
@@ -1,3 +1,3 @@
 module YetiLogger
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
Added `YetiLogger::TestHelper.expect_to_not_see_log_message[s]` for testing that given messages were not logged at the given log level.

Reviewer: @justin-yesware @mkostick 
