### PR TITLE
Vsre 790 timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # yeti_logger changelog
 
+## v3.3.1
+- CustomFormatter uses Time.now instead of Time.now.utc
+
 ## v3.3.0
 - Add custom rails logger formatter
 

--- a/lib/yeti_logger/custom_formatter.rb
+++ b/lib/yeti_logger/custom_formatter.rb
@@ -18,7 +18,7 @@ class YetiLogger::CustomFormatter
   # @param progname [String] unused
   # @param msg [String] - log body
   def call(severity, time, progname, msg)
-    timestamp = Time.now.utc.iso8601(3)
+    timestamp = "#{Time.now.iso8601(3)}"
     pid = Process.pid
     msg = msg.inspect unless msg.is_a?(String)
     msg = "#{msg}\n" unless msg[-1] == ?\n

--- a/lib/yeti_logger/version.rb
+++ b/lib/yeti_logger/version.rb
@@ -1,3 +1,3 @@
 module YetiLogger
-  VERSION = "3.3.0"
+  VERSION = "3.3.1"
 end


### PR DESCRIPTION
Using UTC timestamps at the library level makes the CustomFormatter's timestamps differ from the default Rails log formatter timestamps. This PR changes to using Time.now instead of Time.now.utc for consistency with the default log formatter.

- [x] Update changelog
- [x] Update version.rb

@vendasta/sre 
@vendasta/meerkats 