### PR TITLE
skip logging timestamp in production and staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # yeti_logger changelog
 
+## v3.3.2
+- CustomFormatter does not include timestamp in log in production and staging environments
+
 ## v3.3.1
 - CustomFormatter uses Time.now instead of Time.now.utc
 

--- a/lib/yeti_logger/custom_formatter.rb
+++ b/lib/yeti_logger/custom_formatter.rb
@@ -18,11 +18,11 @@ class YetiLogger::CustomFormatter
   # @param progname [String] unused
   # @param msg [String] - log body
   def call(severity, time, progname, msg)
-    timestamp = "#{Time.now.iso8601(3)}"
+    timestamp = %w(production staging).include?(ENV['RAILS_ENV']) ? "" : "#{Time.now.iso8601(3)} "
     pid = Process.pid
     msg = msg.inspect unless msg.is_a?(String)
     msg = "#{msg}\n" unless msg[-1] == ?\n
-    log_str = "#{timestamp} pid=#{pid}"
+    log_str = "#{timestamp}pid=#{pid}"
 
     tag_str = @tags.map { |k, v|
       value = v.call

--- a/lib/yeti_logger/version.rb
+++ b/lib/yeti_logger/version.rb
@@ -1,3 +1,3 @@
 module YetiLogger
-  VERSION = "3.3.1"
+  VERSION = "3.3.2"
 end


### PR DESCRIPTION
Staging and production environments have timestamps attached by 3rd party services.

@vendasta/sre 
@vendasta/meerkats 