### PR TITLE
Replace deprecation warnings for ActiveSupport Benchmark removal

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,31 @@
+name: Ruby Gem
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 3.4
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4
+
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,8 @@
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
 name: Ruby
+permissions:
+  contents: read
 
 on:
   push:
@@ -19,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # yeti_logger changelog
 
+## v3.3.3
+- Replace deprecated `active_support/core_ext/benchmark` with Ruby's standard `Benchmark` library (fixes Rails 8.2 deprecation warning)
+
 ## v3.3.2
 - CustomFormatter does not include timestamp in log in production and staging environments
 

--- a/lib/yeti_logger.rb
+++ b/lib/yeti_logger.rb
@@ -4,7 +4,7 @@ require 'yeti_logger/constants'
 require 'yeti_logger/configuration'
 require 'yeti_logger/wrapped_logger'
 require 'yeti_logger/message_formatters'
-require 'active_support/core_ext/benchmark'
+require 'benchmark'
 require 'active_support/concern'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/try'
@@ -151,9 +151,7 @@ module YetiLogger
   end
 
   def log_time(action, level = :info)
-    ms = Benchmark.ms do
-      yield
-    end
+    ms = Benchmark.realtime { yield } * 1000
     YetiLogger.logger.send(level,
                            MessageFormatters.build_log_message(self.class.name,
                                                                { action: action,

--- a/lib/yeti_logger/message_formatters.rb
+++ b/lib/yeti_logger/message_formatters.rb
@@ -1,12 +1,3 @@
-# require 'logger'
-# require 'yeti_logger/version'
-# require 'yeti_logger/configuration'
-# require 'active_support/core_ext/benchmark'
-# require 'active_support/concern'
-# require 'active_support/core_ext/object/blank'
-# require 'active_support/core_ext/object/try'
-
-
 # Helper class used to format messages for logging. These can be used
 # directly, but are more convenient when used via YetiLogger
 module YetiLogger::MessageFormatters

--- a/lib/yeti_logger/version.rb
+++ b/lib/yeti_logger/version.rb
@@ -1,3 +1,3 @@
 module YetiLogger
-  VERSION = "3.3.2"
+  VERSION = "3.3.3"
 end

--- a/spec/lib/yeti_logger_spec.rb
+++ b/spec/lib/yeti_logger_spec.rb
@@ -256,6 +256,19 @@ describe YetiLogger do
         sleep 0.01
       end
     end
+
+    it "logs elapsed time in milliseconds" do
+      expect(YetiLogger.logger).to receive(:info) do |msg|
+        expect(msg).to match(/time_ms=\d+/)
+        # Verify it's roughly 100ms (with some tolerance for CI variance)
+        ms = msg.match(/time_ms=(\d+)/)[1].to_i
+        expect(ms).to be_between(80, 200)
+      end
+
+      instance.log_time("query_db") do
+        sleep 0.1
+      end
+    end
   end
 
   describe '#as_logger' do

--- a/yeti_logger.gemspec
+++ b/yeti_logger.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "yard"
-  spec.add_development_dependency "kramdown"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "byebug"
 end


### PR DESCRIPTION
We've been noticing deprecation warnings in the services consuming this gem:

```
DEPRECATION WARNING: active_support/core_ext/benchmark.rb is deprecated and will be removed in Rails 8.2 without replacement.
```

Let's get ahead of this before Rails 8.2 comes out.

---

Also updated the Ruby versions we're testing against to 3.3 and 3.4 (up to date), and added a step to publish to RubyGems on successful build.